### PR TITLE
NN-1165

### DIFF
--- a/src/KeyworkerManagement/App.js
+++ b/src/KeyworkerManagement/App.js
@@ -204,7 +204,8 @@ App.propTypes = {
   resetErrorDispatch: PropTypes.func,
   keyworkerSettingsDispatch: PropTypes.func,
   setMessageDispatch: PropTypes.func.isRequired,
-  setMenuOpen: PropTypes.func.isRequired
+  setMenuOpen: PropTypes.func.isRequired,
+  allowAuto: PropTypes.bool
 };
 
 const mapStateToProps = state => {
@@ -215,7 +216,8 @@ const mapStateToProps = state => {
     config: state.app.config,
     user: state.app.user,
     shouldShowTerms: state.app.shouldShowTerms,
-    menuOpen: state.app.menuOpen
+    menuOpen: state.app.menuOpen,
+    allowAuto: state.keyworkerSettings.allowAuto
   };
 };
 

--- a/src/KeyworkerManagement/index.js
+++ b/src/KeyworkerManagement/index.js
@@ -16,7 +16,7 @@ class HomePage extends Component {
           <div className="pure-u-md-12-12 padding-top"><a className="link backlink" href={getHomeLink()}><img className="back-triangle" src="/images/BackTriangle.png" alt="" width="6" height="10"/> Home</a></div>
           <div className="pure-u-md-8-12 padding-bottom-large">
             <h1 className="heading-large margin-top padding-bottom-40">Manage Key workers</h1>
-            {this.props.user && this.props.user.writeAccess && <div className="pure-u-md-6-12">
+            {this.props.user && this.props.user.writeAccess && this.props.allowAuto && <div className="pure-u-md-6-12">
               <Link id="auto_allocate_link" title="Auto allocate link" className="link" to="/unallocated" >Auto-allocate key workers</Link>
               <div className="padding-right-large">Allocate key workers to prisoners automatically.</div>
             </div>}
@@ -51,7 +51,8 @@ class HomePage extends Component {
 
 HomePage.propTypes = {
   message: PropTypes.string,
-  user: PropTypes.object.isRequired
+  user: PropTypes.object.isRequired,
+  allowAuto: PropTypes.bool
 };
 
 export default HomePage;

--- a/src/KeyworkerManagement/keyworkerManagement.test.js
+++ b/src/KeyworkerManagement/keyworkerManagement.test.js
@@ -11,7 +11,7 @@ describe('HomePage component', () => {
     const user = {
       writeAccess: true
     };
-    const component = shallow(<HomePage message="Hello!" clearMessage={jest.fn()} user={user}/>);
+    const component = shallow(<HomePage message="Hello!" clearMessage={jest.fn()} user={user} allowAuto/>);
     expect(component.find('#auto_allocate_link').length).toBe(1);
     expect(component.find('#keyworker_profile_link').length).toBe(1);
     expect(component.find('#assign_transfer_link').length).toBe(1);
@@ -21,6 +21,32 @@ describe('HomePage component', () => {
       <HomePage
         message="Hello!"
         clearMessage={jest.fn()}
+      />);
+    expect(component.find('#auto_allocate_link').length).toBe(0);
+  });
+  it('should show the auto allocate link when allow autoallocate (keyworker settings) is true and user has writeAccess', () => {
+    const user = {
+      writeAccess: true
+    };
+    const component = shallow(
+      <HomePage
+        message="Hello!"
+        clearMessage={jest.fn()}
+        user={user}
+        allowAuto
+      />);
+    expect(component.find('#auto_allocate_link').length).toBe(1);
+  });
+  it('should hide the auto allocate link when allow autoallocate (keyworker settings) is false and user has writeAccess', () => {
+    const user = {
+      writeAccess: true
+    };
+    const component = shallow(
+      <HomePage
+        message="Hello!"
+        clearMessage={jest.fn()}
+        user={user}
+        allowAuto={false}
       />);
     expect(component.find('#auto_allocate_link').length).toBe(0);
   });


### PR DESCRIPTION
Should hide the auto allocation link on the key worker management page is allow auto allocation is false